### PR TITLE
Use PIL.Image.LANCZOS instead of PIL.Image.ANTIALIAS, which was removed

### DIFF
--- a/goes16background/__main__.py
+++ b/goes16background/__main__.py
@@ -133,7 +133,7 @@ def thread_main(args):
         resize_ratio = min(composite_width / goes16_width, composite_height / goes16_height)
 
         goes16_img = goes16_img.resize((round(goes16_width * resize_ratio), round(goes16_height * resize_ratio)),
-            Image.ANTIALIAS)
+            Image.LANCZOS)
 
         radius_img = min(goes16_width, goes16_height) * resize_ratio / 2
         goes16_center_img = Image.new("RGB", (composite_width, composite_height), "black")


### PR DESCRIPTION
I noticed that the clouds had not moved in a very, very long time.  My observations of the outside seemed at odds with my desktop background.  Upon investigation, it appears simply that the downloading was failing, since `PIL.Image.ANTIALIAS` was removed from Pillow:

https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

`PIL.Image.LANCZOS` does exactly the same thing, it just has a different name now.